### PR TITLE
Provide new readthedocs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,34 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+    # You can also specify other tool versions:
+    # nodejs: "20"
+    # rust: "1.70"
+    # golang: "1.20"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+  # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
+  # builder: "dirhtml"
+  # Fail on all warnings to avoid broken references
+  # fail_on_warning: true
+# Optionally build your docs in additional formats such as PDF and ePub
+# formats:
+#    - pdf
+#    - epub
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# python:
+#    install:
+#    - requirements: docs/requirements.txt

--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,21 @@ First of all install the deps::
 
     $ pipenv install
 
+Then create a new branch, named after the project you wish to redirect::
+
+    $ git checkout -b <myproject>
+
+Modify the ``docs/index.rst`` file and replace the ``<organization>`` and ``<project>`` tags with the appropriate ones::
+
+    $ sed -i 's/<organization>/myorganization/' docs/index.rst
+    $ sed -i 's/<project>/myproject/' docs/index.rst
+
+Commit the modified file and push the branch::
+
+    $ git add docs/index.rst
+    $ git commit -m "Modified index.rst"
+    $ git push -u origin <myproject>
+
 Then check the help::
 
     $ pipenv run python readthedocsredirect.py -h
@@ -19,11 +34,13 @@ Then check the help::
 Now run it with the name of the project (and optionally github repo and org)::
 
     $ pipenv run python readthedocsredirect.py myproject
-    https://myproject.readthedocs.io should now redirect to https://dls-controls.github.io/myproject/master/
+    https://myproject.readthedocs.io should now redirect to https://myorganization.github.io/myproject/
 
 How it works
 ------------
 
-Readthedocs redirects only work on 404, so this replaces the repo with an empty
-one (this repo) and then puts in a static redirect from /en/latest/<something> to
-https://dls-controls.github.io/myproject/master/<something>.
+This project builds an index.html whose entire contents is some Javascript that
+replaces the current URL with the intended redirect URL.
+
+This used to be simpler, but readthedocs now requires several configuration files and
+settings, which means there must be some per-project configuration of this redirector.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,5 @@
+.. raw:: html
+
+    <script type="text/javascript">
+        window.location.replace('https://<organization>.github.io/<project>');
+    </script>


### PR DESCRIPTION
readthedocs introduced new required configuration: https://blog.readthedocs.com/migrate-configuration-v2/

This broke the previous redirection methods, so we now need a per-project redirector setup


This has been deployed to `cothread`: https://cothread.readthedocs.io/  now redirects automatically. Note that some documentation links are broken due to the files themselves moving, to comply with the new Skeleton structure.

Once this is merged I will re-create the `cothread` branch and run the instructions again, as currently the readthedocs configuration is building off my own personal fork.