### PR TITLE
Added another redirect from stable

### DIFF
--- a/readthedocsredirect.py
+++ b/readthedocsredirect.py
@@ -1,6 +1,7 @@
 import argparse
-
+from typing import Set
 import requests
+import re
 
 parser = argparse.ArgumentParser(
     description="Setup a redirect from readthedocs to github.io"
@@ -19,41 +20,116 @@ args = parser.parse_args()
 if args.repo is None:
     args.repo = args.project
 
-TOKEN = open("/dls_sw/prod/etc/tokens/readthedocs.token").read().strip()
-HEADERS = dict(Authorization=f"token {TOKEN}")
-github = f"https://{args.org}.github.io/{args.repo}/master/"
+class Redirecter:
+    TOKEN = open("/dls_sw/prod/etc/tokens/readthedocs.token").read().strip()
+    HEADERS = dict(Authorization=f"token {TOKEN}")
+    TO_URL_FORMAT = r"/\w+/(\w+)/\$rest"
 
-# Change the URL
-response = requests.get(
-    f"https://readthedocs.org/api/v3/projects/{args.project}/", headers=HEADERS
-)
-assert response.ok, response.json()
-data = response.json()
-del data["language"]
-del data["programming_language"]
-data["default_branch"] = args.project
-data["repository"]["url"] = "https://github.com/dls-controls/readthedocsredirect"
-data["homepage"] = github
-response = requests.patch(
-    f"https://readthedocs.org/api/v3/projects/{args.project}/",
-    json=data,
-    headers=HEADERS,
-)
-assert response.ok, response.json()
 
-# Setup a redirect
-response = requests.post(
-    f"https://readthedocs.org/api/v3/projects/{args.project}/redirects/",
-    json=dict(from_url="/en/latest/$rest", to_url=github, type="exact"),
-    headers=HEADERS,
-)
-assert response.ok, response.json()
+    def __init__(self, org: str, repo: str, project):
 
-# Trigger a build
-response = requests.post(
-    f"https://readthedocs.org/api/v3/projects/{args.project}/versions/latest/builds/",
-    headers=HEADERS,
-)
-assert response.ok, response.json()
+        self.project = project
+        self.github_url = f"https://{org}.github.io/{repo}/master/"
+        self.project_url = f"https://readthedocs.org/api/v3/projects/{project}"
+        self.read_the_docs_url = f"https://{project}.readthedocs.io"
 
-print(f"https://{args.project}.readthedocs.io should soon redirect to {github}")
+    def link_project_to_github(self):
+        data= {
+            "default_branch": self.project,
+            "repository": {"url":  "https://github.com/dls-controls/readthedocsredirect"},
+            "homepage": self.github_url,
+        }
+
+        response = requests.patch(
+            self.project_url,
+            json=data,
+            headers=self.HEADERS,
+        )
+        assert response.ok
+
+    def check_redirects(self) -> Set[str]:
+        """
+        Checks for redirects already set up through this script.
+        Errors if redirects are present which aren't expected
+        """
+
+        response = requests.get(
+            f"{self.project_url}/redirects/",
+            headers=self.HEADERS
+        )
+        assert response.ok, response.json()
+
+        already_redirected = set()
+
+        for redirect in response.json()["results"]:
+            match = re.match(self.TO_URL_FORMAT, redirect["from_url"])
+            if redirect["to_url"] != self.github_url or not match:
+                raise RuntimeError(
+                    "Project contains an unknown redirect "
+                    f"{redirect['from_url']} to {redirect['to_url']}. "
+                    "Delete it before proceeding."
+                )
+
+            version_name = match.group(1)
+            already_redirected.add(version_name)
+
+        return already_redirected
+
+    def get_active_versions(self) -> Set[str]:
+        # Set a redirect on all active versions
+        response = requests.get(
+            f"{self.project_url}/versions", headers=self.HEADERS
+        )
+        assert response.ok, response.json()
+        versions = response.json()["results"]
+
+        return set(version["verbose_name"] for version in versions if version["active"])
+
+    def set_up_redirects_on_versions(self, versions: Set[str]):
+        for version_name in versions:
+            # Setup a redirect for 
+            response = requests.post(
+                f"{self.project_url}/redirects/",
+                json=dict(from_url=f"/en/{version_name}/$rest", to_url=self.github, type="exact"),
+                headers=self,
+            )
+            assert response.ok, response.json()
+
+    def redirect(self):
+        print(f"beginning reconfiguration of readthedocs project {self.project}")
+        self.link_project_to_github()
+        print("success")
+        active_versions = self.get_active_versions()
+        print("active versions of project:")
+        for version in active_versions:
+            print(f"    {version}")
+
+        already_redirected_versions = self.check_redirects()
+
+        versions_to_redirect = active_versions.difference(already_redirected_versions)
+
+        if not versions_to_redirect:
+            print("redirects are already set up for every active version")
+            return
+
+        if already_redirected_versions:
+            print("will skip redirects already set up:")
+            for version in already_redirected_versions:
+                print(f"    {version}")
+
+        print("setting up redirects")
+        self.set_up_redirects_on_versions(versions_to_redirect)
+        print("success")
+
+        if "latest" in versions_to_redirect:
+            print("'latest' was redirected, rebuilding it")
+            response = requests.post(
+                f"{self.project_url}/versions/latest/builds/",
+                headers=self.HEADERS,
+            )
+            assert response.ok, response.json()
+
+        print(f"{self.read_the_docs_url} should soon redirect to {self.github_url}")
+
+
+Redirecter(args.org, args.repo, args.project).redirect()


### PR DESCRIPTION
Previously, only the docs on the `latest` readthedocs were being redirected. We also have to redirect `stable`.  The redirect version is arbitrary, the api should accept `stable` even if the docs don't have a stable e.g in the case of malcom.